### PR TITLE
Add kgl_containers library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,37 @@
 cmake_minimum_required( VERSION 3.8.2 )
 
-project( karma LANGUAGES CXX )
 
 #Build Options
-option( BUILD_DOC      "Whether or not documentation should be build"                       OFF ) 
-option( BUILD_UWUMAKER "Whether or not to build the GLSLANG library & UWUMaker executable." ON  ) 
-option( MAJOR_VERSION  "The major component of the version"                                 0   ) 
-option( MINOR_VERSION  "The minor component of the version"                                 1   ) 
-option( PATCH_VERSION  "The patch component of the version"                                 0   ) 
-
+option( OPEPRATING_SYSTEM "The Operating system to build for."                                 "LINUX" )
+option( BUILD_DOC         "Whether or not documentation should be build"                       OFF     ) 
+option( BUILD_UWUMAKER    "Whether or not to build the GLSLANG library & UWUMaker executable." ON      ) 
+option( MAJOR_VERSION     "The major component of the version"                                 0       ) 
+option( MINOR_VERSION     "The minor component of the version"                                 1       ) 
+option( PATCH_VERSION     "The patch component of the version"                                 0       ) 
 set( CMAKE_CXX_STANDARD 17 )
+
+if( OPERATING_SYSTEM STREQUAL "WINDOWS" )
+
+    MESSAGE( "BUILDING FOR WINDOWS" )
+    SET( CMAKE_SYSTEM_NAME Windows)
+
+    # which compilers to use for C and C++
+    SET( CMAKE_C_COMPILER   /usr/bin/x86_64-w64-mingw32-gcc )
+    SET( CMAKE_CXX_COMPILER /usr/bin/x86_64-w64-mingw32-g++ )
+
+    # here is the target environment located
+    SET(CMAKE_FIND_ROOT_PATH  /usr/i586-mingw32msvc /home/alex/mingw-install )
+
+    # adjust the default behaviour of the FIND_XXX() commands:
+    # search headers and libraries in the target environment, search
+    # programs in the host environment
+#    set( CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER )
+#    set( CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY  )
+#    set( CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY  )
+
+endif( OPERATING_SYSTEM STREQUAL "WINDOWS" )
+
+project( karma LANGUAGES CXX )
 
 #Application information.
 set( ENGINE_NAME     "Karma"                       )

--- a/src/data/Pool.cpp
+++ b/src/data/Pool.cpp
@@ -1,6 +1,7 @@
 #include "Pool.h"
 #include "PoolData.h"
 #include <map>
+#include <string>
 
 namespace data
 {

--- a/src/kgl/CMakeLists.txt
+++ b/src/kgl/CMakeLists.txt
@@ -43,6 +43,7 @@ ADD_SUBDIRECTORY   ( io         )
 ADD_SUBDIRECTORY   ( managers   )
 ADD_SUBDIRECTORY   ( vk         )
 ADD_SUBDIRECTORY   ( library    )
+ADD_SUBDIRECTORY   ( containers )
 
 ADD_LIBRARY               ( kgl SHARED  ${KGL_SOURCES} ${KGL_HEADERS} )
 TARGET_LINK_LIBRARIES     ( kgl PRIVATE ${KGL_LIBRARIES}              )

--- a/src/kgl/KGL_Interface.cpp
+++ b/src/kgl/KGL_Interface.cpp
@@ -99,12 +99,12 @@ void KGL_Interface::initialize( const char* base_path )
     data().bus( "required_models"   ).attach( this->kgl_data, &KGL_InterfaceData::addImage      ) ;
     data().bus( "modules_directory" ).attach( this->kgl_data, &KGL_InterfaceData::setModulePath ) ;
 
-    kgl_config_path = path + "/setup.json"             ;
+    kgl_config_path = path + "/setup.json" ;
 
-    data().config     .initialize( kgl_config_path.c_str(), 0                ) ;
-    database_path   = path + "/database.json"          ;
-    mod_path        = path + data().module_path        ;
-    mod_config_path = path + "/kgl_configuration.json" ;
+    data().config     .initialize( kgl_config_path.c_str(), 0 ) ;
+    database_path   = path + "/database.json"                   ;
+    mod_path        = path + data().module_path                 ;
+    mod_config_path = path + "/kgl_configuration.json"          ;
 
     data().config     .initialize( database_path.c_str()  , 0                ) ;
 

--- a/src/kgl/containers/BufferedStack.cpp
+++ b/src/kgl/containers/BufferedStack.cpp
@@ -1,0 +1,142 @@
+#include "BufferedStack.h"
+#include <stack>
+#include <vector>
+#include <mutex>
+
+namespace kgl
+{
+  namespace containers
+  {
+    struct StackEntry
+    {
+      void* data ;
+    };
+
+    struct BufferedStackImplData
+    {
+      typedef void*                 DataEntry     ;
+      typedef std::stack<DataEntry> Stack         ;
+      typedef std::vector<Stack>    LayeredStacks ;
+      
+      std::mutex    mutex        ; ///< TODO
+      LayeredStacks stacks       ; ///< TODO
+      Stack         *curr        ; ///< TODO
+      unsigned      current_swap ; ///< TODO
+      unsigned      element_size ; ///< TODO
+      
+      /**
+       */
+      BufferedStackImplData() ;
+    };
+
+    BufferedStackImplData::BufferedStackImplData()
+    {
+      this->current_swap = 0 ;
+      this->element_size = 0 ;
+    }
+
+    BufferedStackImpl::BufferedStackImpl()
+    {
+      this->bstack_data = new BufferedStackImplData() ;
+    }
+
+    BufferedStackImpl::~BufferedStackImpl()
+    {
+      delete this->bstack_data ;
+    }
+
+    bool BufferedStackImpl::empty()
+    {
+      return data().curr->empty() ;
+    }
+
+    void BufferedStackImpl::swap( int layer )
+    {
+      data().mutex.lock() ;
+      if( layer < 0 )
+      {
+        data().current_swap++ ;
+        data().current_swap = data().current_swap < data().stacks.size() ? data().current_swap : 0 ;
+
+        data().curr = &data().stacks[ data().current_swap ] ;
+      }
+      else if( static_cast<unsigned>( layer ) < data().stacks.size() )
+      {
+        data().current_swap = static_cast<unsigned>( layer ) ;
+        data().curr = &data().stacks[ data().current_swap ]  ;
+      }
+      else
+      {
+        data().current_swap = 0                              ;
+        data().curr = &data().stacks[ data().current_swap ]  ;        
+      }
+      data().mutex.unlock() ;
+    }
+    
+    void BufferedStackImpl::clear()
+    {
+      while( !data().curr->empty() ) data().curr->pop() ;
+    }
+    
+    unsigned BufferedStackImpl::size( int layer ) const
+    {
+      if     ( static_cast<unsigned>( layer ) < 0                    ) return data().curr->size()           ;
+      else if( static_cast<unsigned>( layer ) < data().stacks.size() ) return data().stacks[ layer ].size() ;
+      else                                                             return 0                             ;
+    }
+
+    void BufferedStackImpl::initialize( unsigned layers, unsigned element_size )
+    {
+      data().mutex.lock() ;
+      if( layers > 0 )
+      {
+        data().stacks.resize( layers ) ;
+
+        data().curr         = &data().stacks[ 0 ] ;
+        data().element_size = element_size        ;
+      }
+      data().mutex.unlock() ;
+    }
+
+    void BufferedStackImpl::insertBase( void* val, unsigned layer )
+    {
+      data().mutex.lock() ;
+      if( layer < data().stacks.size() )
+      {
+        data().stacks[ layer ].emplace( val ) ;
+      }
+      data().mutex.unlock() ;
+    }
+
+    void* BufferedStackImpl::popBase()
+    {
+      data().mutex.lock() ;
+      void* val = data().curr->top() ;
+      
+      data().curr->pop() ;
+
+      data().mutex.unlock() ;
+      return val ;
+    }
+
+    unsigned BufferedStackImpl::currentSwap() const
+    {
+      return data().current_swap ;
+    }
+    
+    unsigned BufferedStackImpl::nextSwap() const
+    {
+      return data().current_swap + 1 < data().stacks.size() ? data().current_swap + 1 : 0 ;
+    }
+
+    BufferedStackImplData& BufferedStackImpl::data()
+    {
+      return *this->bstack_data ;
+    }
+
+    const BufferedStackImplData& BufferedStackImpl::data() const
+    {
+      return *this->bstack_data ;
+    }
+  }
+}

--- a/src/kgl/containers/BufferedStack.h
+++ b/src/kgl/containers/BufferedStack.h
@@ -1,0 +1,211 @@
+#ifndef KGL_DOUBLEBUFFEREDSTACK_H
+#define KGL_DOUBLEBUFFEREDSTACK_H
+
+namespace kgl
+{
+  namespace containers
+  {
+    template<typename T, unsigned LAYERS>
+    class BufferedStack ;
+    
+    /**
+     */
+    class BufferedStackImpl
+    {
+      private:
+        template<typename, unsigned> friend class BufferedStack ;
+        
+        /**
+         */
+        void initialize( unsigned layers, unsigned element_size ) ;
+
+        /**
+         */
+        BufferedStackImpl() ;
+        
+        /**
+         */
+        ~BufferedStackImpl() ;
+        /**
+         * @return 
+         */
+        bool empty() ;
+        
+        /**
+         */
+        void clear() ;
+        
+        /**
+         * @return 
+         */
+        unsigned size( int layer ) const ;
+
+        /**
+         */
+        void swap( int layer ) ;
+        
+        /**
+         * @param val
+         * @param element_size
+         */
+        void insertBase( void* val, unsigned layer ) ;
+
+        /**
+         * 
+         * @return 
+         */
+        void* popBase() ;
+        
+        /**
+         */
+        struct BufferedStackImplData* bstack_data ;
+        
+        /**
+         * @return 
+         */
+        unsigned currentSwap() const ;
+        
+        /**
+         * @return 
+         */
+        unsigned nextSwap() const ;
+
+        /**
+         * @return 
+         */
+        BufferedStackImplData& data() ;
+        
+        /**
+         * @return 
+         */
+        const BufferedStackImplData& data() const ;
+    };
+
+    template<typename T, unsigned LAYERS>
+    class BufferedStack
+    {
+      public:
+        
+        /**
+         */
+        BufferedStack() ;
+
+        /**
+         */
+        ~BufferedStack() = default ;
+        
+        /**
+         * @param val
+         */
+        void insert( const T& val, unsigned layer = 0 ) ;
+        
+        /**
+         * @return 
+         */
+        unsigned current() const ;
+        
+        /**
+         * @return 
+         */
+        unsigned next() const ;
+        
+        /**
+         * @return 
+         */
+        unsigned size( int layer = -1 ) const ;
+
+        /**
+         * @return 
+         */
+        void clear() ;
+
+        /**
+         * @return 
+         */
+        T pop() ;
+        
+        /**
+         * @return 
+         */
+        bool empty() ;
+        
+        /**
+         */
+        void swap( int layer = -1 ) ;
+      private:
+        BufferedStackImpl impl ;
+    };
+    
+    
+    template<typename T, unsigned LAYERS>
+    BufferedStack<T, LAYERS>::BufferedStack()
+    {
+      impl.initialize( LAYERS, sizeof( T ) ) ;
+    }
+    
+    template<typename T, unsigned LAYERS>
+    void BufferedStack<T, LAYERS>::insert( const T& val, unsigned layer )
+    {
+      T* tmp = new T( val ) ;
+
+      impl.insertBase( static_cast<void*>( tmp ), layer ) ;
+    }
+
+    template<typename T, unsigned LAYERS>
+    unsigned BufferedStack<T, LAYERS>::next() const
+    {
+      return impl.nextSwap() ;
+    }
+    
+    template<typename T, unsigned LAYERS>
+    unsigned BufferedStack<T, LAYERS>::size( int layer ) const
+    {
+      return impl.size( layer ) ;
+    }
+
+    template<typename T, unsigned LAYERS>
+    unsigned BufferedStack<T, LAYERS>::current() const
+    {
+      return impl.currentSwap() ;
+    }
+    
+    template<typename T, unsigned LAYERS>
+    T BufferedStack<T, LAYERS>::pop()
+    {
+      T  val ;
+      T* ptr ;
+      
+      if( !this->empty() )
+      {
+        ptr = static_cast<T*>( impl.popBase() ) ;
+        val = *ptr                              ;
+        delete ptr                              ;
+      }
+      
+      return val ;
+    }
+    
+    template<typename T, unsigned LAYERS>
+    bool BufferedStack<T, LAYERS>::empty()
+    {
+      return impl.empty() ;
+    }
+
+    template<typename T, unsigned LAYERS>
+    void BufferedStack<T, LAYERS>::clear()
+    {
+      impl.clear() ;
+    }
+    
+    template<typename T, unsigned LAYERS>
+    void BufferedStack<T, LAYERS>::swap( int layer )
+    {
+      impl.swap( layer ) ;
+    }
+  }
+  
+  template<typename T, unsigned LAYERS>
+  using BufferedStack = containers::BufferedStack<T, LAYERS> ;
+}
+#endif /* DOUBLEBUFFEREDSTACK_H */
+

--- a/src/kgl/containers/CMakeLists.txt
+++ b/src/kgl/containers/CMakeLists.txt
@@ -1,0 +1,23 @@
+set( KGL_CONTAINERS_SOURCES 
+     BufferedStack.cpp
+     List.cpp
+   )
+     
+set( KGL_CONTAINERS_HEADERS
+     BufferedStack.h
+     List.h
+   )
+
+set( KGL_CONTAINERS_INCLUDE_DIRS
+   )
+
+set( KGL_CONTAINERS_LIBRARIES
+    )
+
+add_library               ( kgl_containers SHARED   ${KGL_CONTAINERS_SOURCES} ${KGL_CONTAINERS_HEADERS} )
+target_include_directories( kgl_containers PRIVATE  ${KGL_CONTAINERS_INCLUDE_DIRS}                      )
+target_link_libraries     ( kgl_containers PRIVATE  ${KGL_CONTAINERS_LIBRARIES}                         )
+
+add_executable       ( kgl_containers_test test.cpp               )
+target_link_libraries( kgl_containers_test PRIVATE kgl_containers )
+

--- a/src/kgl/containers/List.cpp
+++ b/src/kgl/containers/List.cpp
@@ -1,0 +1,10 @@
+#include "List.h"
+
+namespace kgl
+{
+  namespace containers
+  {
+    
+  }
+}
+

--- a/src/kgl/containers/List.h
+++ b/src/kgl/containers/List.h
@@ -1,0 +1,394 @@
+#ifndef KGL_LIST_H
+#define KGL_LIST_H
+
+namespace kgl
+{
+  namespace containers
+  {
+    template<typename T>
+    class List ;
+
+    template<typename T>
+    class ListIterator
+    {
+      public:
+        
+        /**
+         */
+        ListIterator() ;
+        
+        /**
+         */
+        ~ListIterator() ;
+
+        /**
+         * @return 
+         */
+        ListIterator begin() const ;
+        
+        /**
+         * @return 
+         */
+        ListIterator end() const ;
+        
+        /**
+         * @return 
+         */
+        void seek( unsigned index ) ;
+        
+        /**
+         * @return 
+         */
+        unsigned size() const ;
+        
+        /**
+         * @param iter
+         * @return 
+         */
+        ListIterator& operator=( const ListIterator& iter ) ;
+        
+        /**
+         * @return 
+         */
+        const T& operator*() const ;
+        
+        /**
+         * @return 
+         */
+        T& operator*() ;
+        
+        /**
+         * @param iter
+         * @return 
+         */
+        bool operator!=( const ListIterator& iter ) ;
+        
+        /**
+         * @return 
+         */
+        ListIterator& operator++() ;
+        
+        
+      private:
+        /**
+         */
+        template<typename> friend class List ;
+        
+        T*       data     ; ///< 
+        unsigned data_sz  ; ///< 
+        unsigned location ; ///< 
+    };
+    
+    /**
+     */
+    template<typename T>
+    class List
+    {
+      public:
+        
+        /**
+         */
+        List() ;
+        
+        /**
+         * @param list
+         */
+        List( const List& list ) ;
+        
+        
+        /**
+         * @param size
+         */
+        ~List() ;
+        
+        /**
+         */
+        void clear() ;
+
+        /**
+         * @return 
+         */
+        T* data() ;
+        
+        /**
+         * @param size
+         */
+        const T* data() const ;
+        
+        /**
+         * @param list
+         */
+        void copy( const List<T>& list ) ;
+
+        /**
+         * @param size
+         */
+        void initialize( unsigned size ) ;
+
+        /**
+         * @param val
+         */
+        void insert( T val, unsigned index ) ;
+        
+        /**
+         * @return 
+         */
+        ListIterator<T> begin() ;
+        
+        /**
+         * @param val
+         */
+        void fill( T val ) ;
+        
+        /**
+         * 
+         * @return 
+         */
+        unsigned size() const ;
+
+        /**
+         * @return 
+         */
+        ListIterator<T> end() ;
+        
+        /**
+         * @param index
+         * @return 
+         */
+        T& operator[]( unsigned index ) ;
+        
+        /**
+         * @param index
+         * @return 
+         */
+        const T& operator[]( unsigned index ) const ;
+        
+        /**
+         * @param list
+         * @return 
+         */
+        List& operator=( const List& list ) ;
+
+      private:
+        T*       data_ptr ;
+        unsigned sz       ;
+    };
+    
+    template<typename T>
+    ListIterator<T>& ListIterator<T>::operator=( const ListIterator& iter )
+    {
+      this->data     = iter.data     ;
+      this->location = iter.location ;
+      this->data_sz  = iter.data_sz  ;
+
+      return *this ;
+    }
+    
+    template<typename T>
+    bool ListIterator<T>::operator!=( const ListIterator& iter )
+    {
+      return ( this->location != iter.location || this->data != iter.data ) ;
+    }
+
+    template<typename T>
+    unsigned ListIterator<T>::size() const 
+    {
+      return this->data_sz ;
+    }
+
+    template<typename T>
+    ListIterator<T> ListIterator<T>::begin() const
+    {
+      ListIterator<T> iter ;
+      
+      iter.data     = this->data    ;
+      iter.data_sz  = this->data_sz ;
+      iter.location = 0             ;
+      
+      return iter ;
+    }
+
+    template<typename T>
+    ListIterator<T> ListIterator<T>::end() const
+    {
+      ListIterator<T> iter ;
+      
+      iter.data     = this->data    ;
+      iter.data_sz  = this->data_sz ;
+      iter.location = this->data_sz ;
+    }
+
+    template<typename T>
+    void ListIterator<T>::seek( unsigned index )
+    {
+      this->location = location < this->data_sz ? location : this->data_sz ;
+    }
+
+    template<typename T>
+    ListIterator<T>& ListIterator<T>::operator++()
+    {
+      this->location++ ;
+      return *this ;
+    }
+    
+    template<typename T>
+    T& ListIterator<T>::operator*()
+    {
+      return this->location < this->data_sz ? ( *( this->data + this->location ) ) :  this->data[ 0 ] ;
+    }
+    
+    template<typename T>
+    const T& ListIterator<T>::operator*() const
+    {
+      return this->location < this->data_sz ? ( *( this->data + this->location ) ) :  this->data[ 0 ] ;
+    }
+
+    template<typename T>
+    ListIterator<T>::~ListIterator()
+    {
+      this->data = nullptr ;
+    }
+    
+    template<typename T>
+    ListIterator<T>::ListIterator()
+    {
+      this->data     = nullptr ;
+      this->location = 0       ;
+      this->data_sz     = 0    ;
+    }
+
+    template<typename T>
+    List<T>::List()
+    {
+      this->data_ptr = nullptr ;
+    }
+
+    template<typename T>
+    List<T>::List( const List& list )
+    {
+      this->copy( list ) ;
+    }
+
+    template<typename T>
+    List<T>::~List()
+    {
+      this->clear() ;
+    }
+    
+    template<typename T>
+    void List<T>::clear()
+    {
+      delete this->data_ptr ;
+      this->sz = 0 ;
+    }
+
+    template<typename T>
+    T* List<T>::data()
+    {
+      return this->data_ptr ;
+    }
+    
+    template<typename T>
+    const T* List<T>::data() const
+    {
+      return this->data_ptr ;
+    }
+    
+    template<typename T>
+    unsigned List<T>::size() const
+    {
+      return this->sz ;
+    }
+    
+    template<typename T>
+    void List<T>::copy( const List<T>& list )
+    {
+      if( this->sz != list.sz )
+      {
+        if( this->data_ptr != nullptr )
+        {
+          delete this->data_ptr ;
+        }
+        
+        this->data_ptr = new T[ list.sz ] ;
+        this->sz       = list.sz          ;
+      }
+      
+      for( unsigned i = 0; i < list.sz; i++ ) this->data_ptr[ i ] = list.data_ptr[ i ] ;
+    }
+    
+    template<typename T>
+    void List<T>::initialize( unsigned size )
+    {
+      this->data_ptr = new T[ size ] ;
+      this->sz       = size          ;
+    }
+    
+    template<typename T>
+    void List<T>::insert( T val, unsigned index )
+    {
+      if( index < this->sz ) this->data_ptr[ index ] = val ;
+    }
+    
+    template<typename T>
+    ListIterator<T> List<T>::begin()
+    {
+      ListIterator<T> iter ;
+      
+      iter.data     = this->data_ptr ;
+      iter.location = 0              ;
+      iter.data_sz     = this->sz    ;
+      
+      return iter ;
+    }
+    
+    template<typename T>
+    ListIterator<T> List<T>::end()
+    {
+      ListIterator<T> iter ;
+      
+      iter.data     = this->data_ptr ;
+      iter.location = this->sz       ;
+      iter.data_sz     = this->sz       ;
+      
+      return iter ;
+    }
+    
+    template<typename T>
+    void List<T>::fill( T val )
+    {
+      for( unsigned i = 0; i < this->sz; i++ )
+      {
+        this->data_ptr[ i ] = val ;
+      }
+    }
+
+    template<typename T>
+    T& List<T>::operator[]( unsigned index )
+    {
+      return index < this->sz ? this->data_ptr[ index ] : this->data_ptr[ 0 ] ;
+    }
+    
+    template<typename T>
+    const T& List<T>::operator[]( unsigned index ) const
+    {
+      return index < this->sz ? this->data_ptr[ index ] : this->data_ptr[ 0 ] ;
+    }
+    
+    template<typename T>
+    List<T>& List<T>::operator=( const List& list )
+    {
+      this->copy( list ) ;
+
+      return *this ;
+    }
+  }
+  
+  template<typename T>
+  using List         = containers::List<T> ;
+  
+  template<typename T>
+  using ListIterator = containers::ListIterator<T> ;
+}
+#endif /* LIST_H */
+

--- a/src/kgl/containers/test.cpp
+++ b/src/kgl/containers/test.cpp
@@ -1,0 +1,152 @@
+#include "List.h"
+#include "BufferedStack.h"
+#include <iostream>
+
+bool checkBasicListFunctionality()
+{
+  kgl::List<float> list ;
+  bool             pass ;
+  
+  list.initialize( 100  ) ;
+  list.fill      ( 2.0f ) ;
+  
+  pass = true ;
+  for( unsigned i = 0; i < list.size(); i++ )
+  {
+    if( list[ i ] != 2.0f ) pass = false ;
+  }
+  
+  return pass ;
+}
+
+bool checkListCopy()
+{
+  kgl::List<unsigned> list1 ;
+  kgl::List<unsigned> list2 ;
+  bool             pass  ;
+  
+  list1.initialize( 5 ) ;
+  list1.fill      ( 5 ) ;
+  
+  list2.copy( list1 ) ;
+  
+  pass = true ;
+  for( unsigned i = 0; i < list2.size(); i++ )
+  {
+    if( list2[ i ] != 5 ) pass = false ;
+  }
+  
+  return pass ;
+}
+
+bool checkListIterator()
+{
+  kgl::List<unsigned> list  ;
+  bool                pass  ;
+  unsigned            index ;
+  
+  list.initialize( 5 ) ;
+  list.fill      ( 5 ) ;
+  
+  pass  = true ;
+  index = 0    ;
+  for( auto iter = list.begin(); iter != list.end(); ++iter )
+  {
+    if( *iter != 5 ) pass = false ;
+    index++ ;
+  }
+  
+  if( index != 5 ) pass = false ;
+  index = 0 ;
+
+  for( auto val : list )
+  {
+    if( val != 5 ) pass = false ;
+    index++ ;
+  }
+  
+  if( index != 5 ) pass = false ;
+  return pass ;
+}
+
+bool checkStackFunctionality()
+{
+  struct SimpleStruct
+  {
+    float    a = 0.f ;
+    unsigned b = 0   ;
+  };
+  
+  kgl::BufferedStack<SimpleStruct, 2> stack ;
+  bool                                pass  ;
+  SimpleStruct                        s     ;
+  
+  pass = true ;
+  
+  s.a = 0.0f ;
+  s.b = 0    ;
+  stack.insert( s, 0 ) ;
+  
+  s.a = 5.0f ;
+  s.b = 5    ;
+  stack.insert( s, 1 ) ;
+
+  s.a = 10.0f ;
+  s.b = 10    ;
+  stack.insert( s, 2 ) ;
+  
+  while( !stack.empty() )
+  {
+    auto val = stack.pop() ;
+    
+    if( val.a != 0.0f && val.b != 0 ) pass = false ;
+  }
+  
+  stack.swap() ;
+  
+  while( !stack.empty() )
+  {
+    auto val = stack.pop() ;
+    
+    if( val.a != 5.0f && val.b != 5 ) pass = false ;
+  }
+  
+  stack.swap() ;
+  
+  while( !stack.empty() )
+  {
+    auto val = stack.pop() ;
+    
+    if( val.a != 10.0f && val.b != 10 ) pass = false ;
+  }
+
+  return pass ;
+}
+  
+int main() 
+{
+  bool pass ;
+  
+  std::cout << "Checking List functionality.." << std::endl ;
+  pass = checkBasicListFunctionality() ;
+  if( pass ) std::cout << "Passed!" << std::endl ;
+  else       std::cout << "Failed!" << std::endl << std::endl;
+  
+  std::cout << "Checking List copy.." << std::endl ;
+  pass = checkListCopy() ;
+  if( pass ) std::cout << "Passed!" << std::endl ;
+  else       std::cout << "Failed!" << std::endl << std::endl ;
+  
+  std::cout << "Checking List iterator.." << std::endl ;
+  pass = checkListIterator() ;
+  if( pass ) std::cout << "Passed!" << std::endl ;
+  else       std::cout << "Failed!" << std::endl << std::endl ;
+  
+  std::cout << "Checking Buffered Stack functionality.." << std::endl ;
+  pass = checkStackFunctionality() ;
+  if( pass ) std::cout << "Passed!" << std::endl ;
+  else       std::cout << "Failed!" << std::endl << std::endl ;
+  
+  return 0;
+}
+

--- a/src/kgl/io/CMakeLists.txt
+++ b/src/kgl/io/CMakeLists.txt
@@ -17,10 +17,12 @@ set( KGL_IO_HEADERS
 
 set( KGL_IO_INCLUDE_DIRS
     ${DATA_BUS_DIR}
+    ${SDL2_INCLUDE_DIRS}
    )
 
 set( KGL_IO_LIBRARIES
      data_bus
+     ${SDL2_LIBRARIES}
    )
 
 add_library( kgl_io SHARED ${KGL_IO_SOURCES} ${KGL_IO_HEADERS} )

--- a/src/kgl/io/ObjectLoader.cpp
+++ b/src/kgl/io/ObjectLoader.cpp
@@ -10,12 +10,17 @@
 
   static inline LibHandle loadSharedObject( const char* input )
   {
-    return LibHandle() ;
+    return dlopen( input ) ;
   }
 
   static inline const char* getError()
   {
     return "Windows Error handler not yet implemented." ;
+  }
+
+  static inline void releaseHandle( LibHandle handle )
+  {
+    FreeLibrary( handle ) ;
   }
 
 #elif __linux__ 

--- a/src/kgl/vk/context/CommandBuffer.h
+++ b/src/kgl/vk/context/CommandBuffer.h
@@ -43,10 +43,21 @@ namespace kgl
           ~CommandBuffer() ;
           
           /**
+           * @param buff
+           */
+          CommandBuffer( const CommandBuffer& buff ) ;
+          
+          /**
            * @param window_name
            * @param gpu
            */
           void initialize( const char* window_name, unsigned gpu, unsigned count, BufferLevel level = BufferLevel::Primary ) ;
+          
+          /**
+           * @param buff
+           * @return 
+           */
+          CommandBuffer& operator=( const CommandBuffer& buff ) ;
           
           /** Method to return the name of the window this command buffer is associated with.
            * @return The name of the window this command buffer is associated with.
@@ -187,6 +198,11 @@ namespace kgl
           /**
            */
           CommandBuffer() ;
+          
+          /**
+           * @param buff
+           */
+          CommandBuffer( const CommandBuffer& buff ) ;
         
           /**
            * @param gpu
@@ -194,6 +210,11 @@ namespace kgl
            */
           ~CommandBuffer() ;
         
+          /**
+           * @param buff
+           * @return 
+           */
+          CommandBuffer& operator=( const CommandBuffer& buff ) ;
           /**
            * @param command
            */

--- a/src/kgl/vk/context/Image.cpp
+++ b/src/kgl/vk/context/Image.cpp
@@ -377,6 +377,13 @@ namespace kgl
       this->img_data = new ImageData() ;
     }
     
+    Image::Image( const Image& image )
+    {
+      this->img_data = new ImageData() ;
+      *this->img_data = *image.img_data ;
+      data().cmd_buffer = image.data().cmd_buffer ;
+    }
+    
     Image::~Image()
     {
       delete this->img_data ;
@@ -475,6 +482,18 @@ namespace kgl
       img.data().transitionLayout( img.data().format, ::vk::ImageLayout::eTransferSrcOptimal, old_layout                  ) ;
     }
 
+    Image& Image::operator=( const Image& image )
+    {
+      *this->img_data = *image.img_data ;
+      data().cmd_buffer = image.data().cmd_buffer ;
+      return *this ;
+    }
+
+    bool Image::operator<( const Image& image ) const
+    {
+      return ( this->data().image_view ) < ( image.data().image_view ) ;
+    }
+        
     void Image::initialize( unsigned gpu, unsigned w, unsigned h ) 
     {
       const ::kgl::vk::compute::Context context ;

--- a/src/kgl/vk/context/Image.h
+++ b/src/kgl/vk/context/Image.h
@@ -17,8 +17,11 @@ namespace kgl
     {
       public:
         Image() ;
+        Image( const Image& image ) ;
         ~Image() ;
         void initialize( unsigned gpu, unsigned w, unsigned h ) ;
+        Image& operator=( const Image& image ) ;
+        bool operator<( const Image& image ) const ;
         const ::vk::Sampler sampler() const ;
         const ::vk::ImageView view() const ;
         void setLayout( const ::vk::ImageLayout& layout ) ;

--- a/src/kgl/vk/context/Window.cpp
+++ b/src/kgl/vk/context/Window.cpp
@@ -119,7 +119,7 @@ namespace kgl
       fence_info.setFlags( ::vk::FenceCreateFlagBits::eSignaled ) ;
 
       data().window = SDL_CreateWindow( name, 500, 500, width, height, SDL_WINDOW_VULKAN | SDL_WINDOW_SHOWN ) ;
-  
+      
       data().surface.initialize( *data().window                ) ;
       data().device .initialize( data().surface.surface(), gpu ) ;
       data().chain  .initialize( data().surface, data().device ) ;
@@ -220,8 +220,7 @@ namespace kgl
     {
       const ::vk::Fence fence = data().fences.at( data().current_frame ) ;
       ::data::module::Bus bus   ;
-      
-      if( data().current_frame == 0 )
+      if( data().current_frame < 1 )
       {
         data().device.device().waitForFences( 1, &fence, true, UINT64_MAX ) ;
         data().device.device().resetFences  ( 1, &fence                   ) ;
@@ -229,11 +228,11 @@ namespace kgl
         
         data().current_img = result.value ;
         data().current_frame++ ;
-//        data().current_frame = data().current_frame + 1 % ( data().conf.max_frames_in_flight - 1 ) ;
+        
         bus( "start" ).emit( data().sync ) ;
       }
 
-      while( data().current_frame != 0 ) {} ;
+      while( data().current_frame >= 1 ) {} ;
     }
 //    void Window::setName( const char* name )
 //    {

--- a/src/kgl/vk/modules/present/CMakeLists.txt
+++ b/src/kgl/vk/modules/present/CMakeLists.txt
@@ -13,6 +13,7 @@ set( KGL_VK_PRESENT__MODULE_INCLUDE_DIRS
 
 set( KGL_VK_PRESENT__MODULE_LIBRARIES
      data_bus
+     kgl_containers
      kgl_vk_module
      kgl
    )

--- a/src/kgl/vk/modules/render/CMakeLists.txt
+++ b/src/kgl/vk/modules/render/CMakeLists.txt
@@ -15,6 +15,7 @@ set( KGL_VK_RENDER_MODULE_MODULE_INCLUDE_DIRS
 
 set( KGL_VK_RENDER_MODULE_MODULE_LIBRARIES
      data_bus
+     kgl_containers
      kgl_vk_module
      kgl
    )

--- a/src/kgl/vk/modules/spritesheet/SpriteSheet.cpp
+++ b/src/kgl/vk/modules/spritesheet/SpriteSheet.cpp
@@ -1,1 +1,390 @@
+#define GLM_FORCE_RADIANS
+#define GLM_FORCE_DEPTH_ZERO_TO_ONE
+#define GLM_FORCE_LEFT_HANDED
+#include "Render2D.h"
+#include "Bus.h"
+#include "Signal.h"
+#include <vk/node/Synchronization.h>
+#include "vk/context/Buffer.h"
+#include "vk/context/Window.h"
+#include "vk/context/Swapchain.h"
+#include <vk/context/Pipeline.h>
+#include <vk/context/Uniform.h>
+#include <vk/context/Uniform.h>
+#include <vk/context/Descriptor.h>
+#include <vk/context/RenderPass.h>
+#include <vk/context/Context.h>
+#include <vk/context/Image.h>
+#include <vk/context/CommandBuffer.h>
+#include <managers/AssetManager.h>
+#include <vulkan/vulkan.hpp>
+#include <DrawCommand.h>
+#include <glm/glm/glm.hpp>
+#include <glm/glm/gtx/transform.hpp>
+#include <string>
+#include <stack>
+
+#include <sstream>
+#include <iostream>
+#include <map>
+
+static inline const float vertex_data[] = 
+{ 
+  // pos      // tex
+  0.0f, 1.0f, 0.0f, 1.0f,
+  1.0f, 0.0f, 1.0f, 0.0f,
+  0.0f, 0.0f, 0.0f, 0.0f, 
+
+  0.0f, 1.0f, 0.0f, 1.0f,
+  1.0f, 1.0f, 1.0f, 1.0f,
+  1.0f, 0.0f, 1.0f, 0.0f
+};
+
+namespace kgl
+{
+  namespace vk
+  {      
+    struct Render2DData
+    {
+      struct Material
+      {
+        Uniform       uniform ;
+        DescriptorSet set     ;
+      };
+
+      typedef std::stack<ImageCommand>        Commands  ;
+      typedef std::map<std::string, Material> Materials ;
+      
+      ::kgl::vk::render::Context       context           ; ///< The context to use for vulkan state information.
+       Materials                       materials         ; ///< Objects to contain all data to be sent to a uniform.
+      ::kgl::vk::Window*               window            ; ///< The window this object is a child of.
+      ::kgl::vk::render::CommandBuffer buffer            ; ///< The command buffer to use for all GPU calls.
+      ::kgl::vk::render::Pipeline      pipeline          ; ///< The pipeline that is associated with this object's rendering.
+      ::kgl::vk::RenderPass            pass              ; ///< The render pass that defines this object's rendering.
+      ::kgl::vk::Buffer                vertices          ; ///< The buffer that contains the vertex data that this object uses to render.
+      ::kgl::vk::DescriptorPool        pool              ; ///< The object that contains the metadata to make descriptor sets.
+      ::kgl::vk::Synchronization       sync              ; ///< Synchronization object for managing GPU-GPU & GPU-CPU Synchronization.
+      ::kgl::man::AssetManager         manager           ; ///< Asset manager object for grabbing loaded images.
+      ::data::module::Bus              bus               ; ///< The data bus to use for communication with the rest of the program.
+      unsigned                         gpu               ; ///< The GPU to use for this object's operations.
+      glm::mat4                        model_matrix      ; ///< The transformation matrix for this object to use in rendering.
+      glm::mat4                        projection        ; ///< The projection matrix that converts pixel locations to NDC coordinates.
+      ::vk::Device                     device            ; ///< The handle of vulkan device this object uses.
+      std::string                      window_name       ; ///< The name of this object's window.
+      std::string                      output_name       ; ///< The name of this object's synchronization output.
+      std::string                      output_image_name ; ///< The name of this object's framebuffer output.
+      std::string                      name              ; ///< The name of this module.
+      ImageCommand                     current_cmd       ; ///< The current command that is being processed.
+      Commands                         commands          ; ///< The stack of commands this object is to process when kicked.
+      unsigned                         current_cmd_index ; ///< The current index of command being processed.
+
+      /** Default Constructor. Initializes member data.
+       */
+      Render2DData() ;
+      
+      /** Method to set this object's window's name.
+       * @param name The name of window this object uses.
+       */
+      void setWindowName( const char* name ) ;
+      
+      /** Method to pop a command off the stack for processing.
+       */
+      void pop() ;
+
+      /** Method to set the GPU this object uses for operations.
+       */
+      void setGPU( unsigned gpu ) ;
+
+      /** Method to set this object's output framebuffer name.
+       * @param output The name of this object's framebuffer output.
+       */
+      void setOutputImageName( const char* output ) ;
+      
+      /** Method to push a command to this object for operation.
+      */
+      void setCommand( const ::kgl::ImageCommand& cmd ) ;
+      
+      /** Method to prepare the transformation matrix of this object for rendering.
+       */
+      void setUpModelMatrix() ;
+
+      /** Method to recieve a synchronization object for rendering synchronization.
+       * @param sync The object to wait on for operations.
+       */
+      void input ( const ::kgl::vk::Synchronization& sync ) ;
+      
+      /** Method to output this object's data.
+       */
+      void output() ;
+
+      /** Method to set the name of this object's synchronization input.
+       */
+      void setInputName( const char* name ) ;
+      
+      /** Method to set the name of this object's synchronization output.
+       */
+      void setOutputName( const char* name ) ;
+    };
+    
+    Render2DData::Render2DData()
+    {
+      this->current_cmd_index = 0 ;
+    }
+    
+    void Render2DData::pop()
+    {
+      this->current_cmd = this->commands.top() ;
+      this->commands.pop() ;
+    }
+
+    void Render2DData::setCommand( const ::kgl::ImageCommand& cmd )
+    {
+        auto iter = this->materials.find( cmd.image() ) ;
+        
+        this->commands.emplace( cmd ) ;
+        
+        // If we don't have enough uniform objects for the amount of commands we have, scale up.
+        if( iter == this->materials.end() )
+        {
+          if( this->manager.contains( cmd.image() ) )
+          {
+            auto mat = this->materials.emplace( cmd.image(), Material() ) ;
+            
+            mat.first->second.set = this->pool.makeDescriptorSet( this->pass.numBuffers()     ) ;
+            mat.first->second.uniform.initialize( this->gpu                                   ) ;
+            mat.first->second.uniform.addImage  ( "image", this->manager.image( cmd.image() ) ) ;
+            mat.first->second.set.set( mat.first->second.uniform ) ;
+          }
+        }
+    }
+    
+    void Render2DData::setUpModelMatrix()
+    {
+      const float       x   = this->current_cmd.posX()     ;
+      const float       y   = this->current_cmd.posY()     ;
+      const float       w   = this->current_cmd.width()    ;
+      const float       h   = this->current_cmd.height()   ;
+      const float       r   = this->current_cmd.rotation() ;
+      const std::string img = this->current_cmd.image()    ;
+
+      glm::vec2 size ;
+     
+      if( w < 0.1f && h < 0.1f && this->manager.contains( img.c_str() ) )
+      {
+        const auto image = &this->manager.image( this->current_cmd.image() ) ;
+        size = glm::vec2( image->width(), image->height() ) ;
+      }
+      else
+      {
+        size = glm::vec2( w, h ) ;
+      }
+
+      this->model_matrix = glm::mat4( 1.f ) ;
+      
+      glm::vec3 pos( x, y, 0.0f ) ;
+      this->model_matrix = glm::translate( this->model_matrix, pos ) ;
+      
+      this->model_matrix = glm::translate( this->model_matrix, glm::vec3   ( 0.5f  * w , 0.5f * h, 0.0f        ) ) ; 
+      this->model_matrix = glm::rotate   ( this->model_matrix, glm::radians( r ), glm::vec3( 0.0f, 0.0f, 1.0f ) ) ; 
+      this->model_matrix = glm::translate( this->model_matrix, glm::vec3   ( -0.5f * w, -0.5f * h, 0.0f       ) ) ;
+
+      this->model_matrix = glm::scale( this->model_matrix, glm::vec3( size, 1.0f ) ) ; 
+    }
+
+    void Render2DData::setOutputImageName( const char* output ) 
+    {
+      this->output_image_name = output ;
+    }
+
+    void Render2DData::setWindowName( const char* name )
+    {
+      this->window_name = name ;
+    }
+
+    void Render2DData::setGPU( unsigned gpu )
+    {
+      this->gpu    = gpu                                ;
+      this->device = this->context.virtualDevice( gpu ) ;
+    }
+    
+    void Render2DData::input( const ::kgl::vk::Synchronization& sync )
+    {
+      this->sync.copy( sync ) ;
+//      this->pool.reset() ;
+    }
+
+    void Render2DData::output()
+    {
+      const unsigned index = this->context.currentSwap( this->window_name.c_str() ) ;
+     
+      this->bus( this->output_name      .c_str() ).emit( this->sync                ) ;
+      this->bus( this->output_image_name.c_str() ).emit( this->pass.image( index ) ) ;
+    }
+
+    void Render2DData::setInputName( const char* name )
+    {
+      static bool found_input = false ;
+
+      // We now know what input we're getting. Subscribe & add as a dependancy.
+      if( !found_input )
+      {
+        this->bus( name ).attach       ( this, &Render2DData::input                     ) ;
+        this->bus( name ).addDependancy( this, &Render2DData::input, this->name.c_str() ) ;
+        found_input = true ;
+      }
+    }
+
+    void Render2DData::setOutputName( const char* name )
+    {
+      this->output_name = name ;
+    }
+
+    Render2D::Render2D()
+    {
+      this->data_2d = new Render2DData() ;
+    }
+    
+    Render2D::~Render2D()
+    {
+      delete this->data_2d ;
+    }
+
+    void Render2D::resize()
+    {
+      
+      data().projection = glm::ortho(0.0f, (float)data().window->chain().width(), (float)data().window->chain().height(), 0.0f, -1.0f, 1.0f) ;
+    }
+
+    void Render2D::initialize()
+    {
+      const unsigned     MAX_SETS = 200                                                 ; ///< The max number of descriptor sets allowed.
+      const unsigned     width    = data().context.width ( data().window_name.c_str() ) ; ///< Width of the screen.
+      const unsigned     height   = data().context.height( data().window_name.c_str() ) ; ///< Height of the screen.
+      static const char* path     = "/uwu/render2d.uwu"                                 ; ///< Path to this object's shader in the local-directory.
+      std::string pipeline_path ;
+      
+      // Build path to this object's shdder.
+      pipeline_path = ::kgl::vk::basePath() ;
+      pipeline_path = pipeline_path + path  ;
+      
+      data().pipeline.setPushConstantByteSize ( sizeof( glm::mat4 ) * 2                                     ) ;
+      data().pipeline.setPushConstantStageFlag( static_cast<unsigned>( ::vk::ShaderStageFlagBits::eVertex ) ) ;
+
+      // Initialize vulkan objects.
+      data().vertices.initialize<float>( data().gpu, Buffer::Type::VERTEX, 24                                                   ) ;
+      data().pass    .initialize       ( data().window_name.c_str(), data().gpu                                                 ) ;
+      data().buffer  .initialize       ( data().window_name.c_str(), data().gpu, data().pass.numBuffers(), BufferLevel::Primary ) ;
+      data().pipeline.initialize       ( pipeline_path.c_str(), data().gpu, width, height, data().pass.pass()                   ) ;
+      data().pool    .initialize       ( data().gpu, MAX_SETS, data().pipeline.shader()                                         ) ;
+      data().sync    .initialize       ( data().gpu                                                                             ) ;
+      
+      // Initialize data.
+      data().window     = &data().context.window( data().window_name.c_str() )                ;
+      data().projection = glm::ortho(  0.0f, (float)width, 0.0f, (float)height, -1.0f, 1.0f ) ;
+      
+      // Copy vertex data to the device.
+      data().vertices.copyToDevice( vertex_data ) ;
+    }
+
+    void Render2D::shutdown()
+    {
+//      data().sync    .reset() ; ///TODO
+//      data().uniform .reset() ; ///TODO
+      data().vertices.reset() ; 
+//      data().pass    .reset() ; ///TODO
+//      data().buffer  .reset() ; ///TODO
+//      data().pipeline.reset() ; ///TODO
+    }
+
+    void Render2D::subscribe( const char* pipeline, unsigned id )
+    {
+      const std::string json_path = std::string( "Graphs::" ) + std::string( pipeline ) + std::string( "::Modules::" ) + std::string( this->name() ) ;
+      data().name = this->name() ;
+      data().pass.subscribe( this->name(), id ) ;
+      
+      data().pipeline.subscribe( json_path.c_str(), id ) ;
+      
+      // Graph-specific JSON-parameters.
+      data().bus( "Graphs::", pipeline, "::window" ).attach( this->data_2d, &Render2DData::setWindowName ) ;
+      data().bus( "Graphs::", pipeline, "::gpu"    ).attach( this->data_2d, &Render2DData::setGPU        ) ;
+      
+      // Module-specific JSON-parameters.
+      data().bus( json_path.c_str(), "::input"        ).attach( this->data_2d, &Render2DData::setInputName       ) ;
+      data().bus( json_path.c_str(), "::output"       ).attach( this->data_2d, &Render2DData::setOutputName      ) ;
+      data().bus( json_path.c_str(), "::output_image" ).attach( this->data_2d, &Render2DData::setOutputImageName ) ;
+
+      // Graph-specific inputs.
+      data().bus( this->name(), "::cmd" ).attach( this->data_2d, &Render2DData::setCommand ) ;
+
+      // Add dependancies for this module's operation.
+      data().bus( "" ).onCompletion( this->name(), dynamic_cast<Module*>( this ), &Render2D::kick ) ;
+      data().bus( this->name(), "::cmd" ).addDependancy( this->data_2d, &Render2DData::setCommand, data().name.c_str() ) ;
+      
+      // Set our own Render Pass information, but allow it to be overwritten by JSON configuration.
+      data().bus( json_path.c_str(), "::ViewportX"        ).emit( 0, 0.f ) ;
+      data().bus( json_path.c_str(), "::ViewportY"        ).emit( 0, 0.f ) ;
+      data().bus( json_path.c_str(), "::ViewportMinDepth" ).emit( 0, 0.f ) ;
+      data().bus( json_path.c_str(), "::ViewportMaxDepth" ).emit( 0, 1.f ) ;
+    }
+
+    void Render2D::execute()
+    {
+      struct Transformation
+      {
+        glm::mat4 model ;
+        glm::mat4 proj  ;
+      };
+
+      Transformation transform ;
+
+      if( !data().commands.empty() )
+      {
+
+        data().buffer.record( data().pass ) ;
+        while( !data().commands.empty() )
+        {
+          // Pop latest draw command off the stack.
+          data().pop() ;
+          
+          // Build Transformation Matrix.
+          data().setUpModelMatrix() ;
+
+          auto iter = data().materials.find( data().current_cmd.image() ) ;
+
+          // Bind pipeline and descriptor set to the command buffer.
+          data().pipeline.bind( data().buffer, iter->second.set ) ;
+          
+          // Push Transformations to the GPU.
+          transform.model = data().model_matrix ;
+          transform.proj  = data().projection   ;
+          data().buffer.pushConstant( transform, data().pipeline.layout(), static_cast<unsigned>( ::vk::ShaderStageFlagBits::eVertex ), 1 ) ;
+
+          // Draw using vertices.
+          data().buffer.draw( data().vertices.buffer(), 24 ) ;
+          
+          // Increment the index of the current command being processed.
+          data().current_cmd_index++ ;
+        }
+        
+        // Stop recording the command buffer & Submit to the graphics queue.
+        data().buffer.stop() ;
+        data().pass.submit( data().sync, data().buffer ) ;
+        
+        // Output our synchronization to next module in the graph & reset command index.
+        data().output() ;
+        data().current_cmd_index = 0 ;
+      }
+    }
+
+    Render2DData& Render2D::data()
+    {
+      return *this->data_2d ;
+    }
+
+    const Render2DData& Render2D::data() const
+    {
+      return *this->data_2d ;
+    }
+  }
+}
 


### PR DESCRIPTION
Changelog:
*Added kgl_containers library ( List & BufferedStack objects ) for use both internally and externally for communication with the kgl library. Will prob move out of kgl when work on kal is moving along.
*Got rid of ugly stack behaviour of Render2D/Present modules in favor of using new BufferedStack object instead.
*Fixed more issues with Windows build.